### PR TITLE
feat: add display settings with auto-close option for translation popup

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -9,8 +9,8 @@
       }
       html,
       body {
-        font-family:
-          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+          sans-serif;
         padding: 0;
         margin: 0;
         background: #f5f5f5;
@@ -165,6 +165,22 @@
         color: #721c24;
         display: block;
       }
+      .checkbox-group {
+        display: flex;
+        align-items: center;
+        margin-bottom: 20px;
+      }
+      input[type='checkbox'] {
+        width: 18px;
+        height: 18px;
+        margin-right: 10px;
+        cursor: pointer;
+      }
+      .checkbox-label {
+        cursor: pointer;
+        user-select: none;
+        font-weight: normal;
+      }
     </style>
   </head>
   <body>
@@ -174,6 +190,7 @@
         <button class="tab" onclick="switchTab('custom-prompt')">Custom Prompt</button>
         <button class="tab" onclick="switchTab('custom-model')">Custom Model</button>
         <button class="tab" onclick="switchTab('custom-languages')">Custom Languages</button>
+        <button class="tab" onclick="switchTab('display')">Display</button>
       </div>
       <button class="save-btn tab-save-btn" id="save-all-btn" onclick="saveAll()">Save</button>
     </div>
@@ -292,6 +309,25 @@ Ancient Greek"
           <div class="status" id="custom-languages-status"></div>
         </div>
       </div>
+
+      <div id="display" class="tab-panel">
+        <div class="container">
+          <h2>Display Settings</h2>
+
+          <div class="checkbox-group">
+            <input type="checkbox" id="auto-close-on-blur" />
+            <label for="auto-close-on-blur" class="checkbox-label">
+              Auto-close translation popup when it loses focus
+            </label>
+          </div>
+          <div class="help-text" style="margin-top: -15px; margin-left: 28px">
+            When enabled, the translation popup will automatically close when you click outside of
+            it.
+          </div>
+
+          <div class="status" id="display-status"></div>
+        </div>
+      </div>
     </div>
 
     <script>
@@ -302,6 +338,7 @@ Ancient Greek"
         customPrompt: false,
         customModel: false,
         customLanguages: false,
+        display: false,
       };
 
       // Tab switching
@@ -319,6 +356,7 @@ Ancient Greek"
         ipcRenderer.send('load-custom-prompt');
         ipcRenderer.send('load-custom-model');
         ipcRenderer.send('load-custom-languages');
+        ipcRenderer.send('load-auto-close-on-blur');
 
         // Add change listeners
         document
@@ -342,6 +380,9 @@ Ancient Greek"
         document
           .getElementById('custom-languages-input')
           .addEventListener('input', () => (pendingChanges.customLanguages = true));
+        document
+          .getElementById('auto-close-on-blur')
+          .addEventListener('change', () => (pendingChanges.display = true));
       });
 
       // API Keys functionality
@@ -439,6 +480,25 @@ Ancient Greek"
         }
       });
 
+      // Display settings functionality
+      ipcRenderer.on('auto-close-on-blur-loaded', (event, autoCloseOnBlur) => {
+        document.getElementById('auto-close-on-blur').checked = autoCloseOnBlur;
+      });
+
+      function saveDisplaySettings() {
+        const autoCloseOnBlur = document.getElementById('auto-close-on-blur').checked;
+        ipcRenderer.send('save-auto-close-on-blur', autoCloseOnBlur);
+      }
+
+      ipcRenderer.on('auto-close-on-blur-saved', (event, success) => {
+        if (success) {
+          pendingChanges.display = false;
+          showStatus('Display settings saved successfully!', false);
+        } else {
+          showStatus('Failed to save display settings. Please try again.', true);
+        }
+      });
+
       // Save all function
       function saveAll() {
         const saveBtn = document.getElementById('save-all-btn');
@@ -456,12 +516,16 @@ Ancient Greek"
         if (pendingChanges.customLanguages) {
           saveCustomLanguages();
         }
+        if (pendingChanges.display) {
+          saveDisplaySettings();
+        }
 
         if (
           !pendingChanges.apiKeys &&
           !pendingChanges.customPrompt &&
           !pendingChanges.customModel &&
-          !pendingChanges.customLanguages
+          !pendingChanges.customLanguages &&
+          !pendingChanges.display
         ) {
           showStatus('No changes to save', false);
         }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -42,6 +42,7 @@ function getDefaultConfig(): Config {
     secondaryLanguage: secondaryLang,
     isPaused: false,
     aiModel: DEFAULT_AI_MODEL,
+    autoCloseOnBlur: false,
     customPrompt: '',
     displayMode: 'notification',
   };
@@ -72,6 +73,11 @@ export function initializeConfig(): void {
   // Initialize display mode if not present
   if (config.displayMode === undefined) {
     config.displayMode = 'notification';
+  }
+
+  // Initialize autoCloseOnBlur if not present
+  if (config.autoCloseOnBlur === undefined) {
+    config.autoCloseOnBlur = false;
   }
 
   // Restore isPaused state

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -16,6 +16,7 @@ export interface Config {
   secondaryLanguage: string;
   isPaused: boolean;
   aiModel: string;
+  autoCloseOnBlur?: boolean;
   customPrompt: string;
   displayMode: DisplayMode;
   customModel?: CustomModel;

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, screen, ipcMain, clipboard } from 'electron';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { cancelCurrentTranslation } from '../keyboard/handler.ts';
+import { getConfig } from '../config/index.ts';
 
 // Get __dirname in both ESM and CommonJS
 const getCurrentDir = (): string => {
@@ -80,8 +81,15 @@ export function showTranslationPopup(translation: string | null, originalText: s
     }
   });
 
-  // Remove blur event handler to prevent closing on click outside
-  // Users should use the close button or copy button to close the window
+  // Add blur event handler based on user preference
+  const config = getConfig();
+  if (config.autoCloseOnBlur) {
+    popupWindow.on('blur', () => {
+      if (popupWindow && !popupWindow.isDestroyed()) {
+        popupWindow.close();
+      }
+    });
+  }
 
   popupWindow.on('closed', () => {
     popupWindow = null;

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -91,4 +91,14 @@ export function setupSettingsIPC(): void {
     updateConfig({ customLanguages });
     event.reply('custom-languages-saved', true);
   });
+
+  ipcMain.on('load-auto-close-on-blur', event => {
+    const config = getConfig();
+    event.reply('auto-close-on-blur-loaded', config.autoCloseOnBlur ?? false);
+  });
+
+  ipcMain.on('save-auto-close-on-blur', (event, autoCloseOnBlur: boolean) => {
+    updateConfig({ autoCloseOnBlur });
+    event.reply('auto-close-on-blur-saved', true);
+  });
 }


### PR DESCRIPTION
## Summary
Added a new display setting that allows users to enable automatic closing of the translation popup when it loses focus. The setting is **disabled by default** to maintain existing behavior.

## Changes
- Added `autoCloseOnBlur` setting to the config system
- Translation popup now optionally closes when clicking outside (if enabled)
- New "Display" tab in settings with a checkbox to toggle this feature

## Implementation
When enabled, the popup window adds a blur event handler that closes it automatically. When disabled (default), users must use the close or copy buttons as before.

## Testing
- ✅ Setting persists across restarts
- ✅ Default behavior unchanged
- ✅ Build passes
