### PR TITLE
fix: correct formatting of font-family in settings.html

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -9,8 +9,8 @@
       }
       html,
       body {
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
-          sans-serif;
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
         padding: 0;
         margin: 0;
         background: #f5f5f5;


### PR DESCRIPTION
## Summary
Fixed Prettier formatting issues in `settings.html` that were causing CI to fail.
Ref: https://github.com/rot1024/honyo/actions/runs/16721364719

## Changes
- Ran `npm run format` to fix code style issues in `settings.html`
- No functional changes, only formatting adjustments

## Testing
- ✅ `npm run format:check` now passes
- ✅ CI checks should now succeed